### PR TITLE
fix R interpreter to work with environement module on supercomputer

### DIFF
--- a/inst/tools/2d_map.R
+++ b/inst/tools/2d_map.R
@@ -1,4 +1,4 @@
-#!/usr/bin/Rscript
+#!/usr/bin/env Rscript
 # Print the MPI Owner distribution considering a 2D structure of data
 
 library(starvz)

--- a/inst/tools/phase1-workflow.R
+++ b/inst/tools/phase1-workflow.R
@@ -1,4 +1,4 @@
-#!/usr/bin/Rscript
+#!/usr/bin/env Rscript
 library(starvz)
 
 ##############################

--- a/inst/tools/phase2-memsnaps.R
+++ b/inst/tools/phase2-memsnaps.R
@@ -1,4 +1,4 @@
-#!/usr/bin/Rscript
+#!/usr/bin/env Rscript
 # Call function memsnaps from start to end with informed steps
 
 library(starvz)

--- a/inst/tools/phase2-workflow.R
+++ b/inst/tools/phase2-workflow.R
@@ -1,4 +1,4 @@
-#!/usr/bin/Rscript
+#!/usr/bin/env Rscript
 library(starvz)
 library(ggplot2)
 


### PR DESCRIPTION
I work on a supercomputer. On this cluster, we use modules which allows us to have several different environments at our disposal. So there is no R interpreter in  /usr/bin/Rscript.
This PR should work on all platforms.

Maybe this correction need to be applied in other R script.