### PR TITLE
[Draft] Fix ResourceId Handling in read_dag to Prevent stoi Errors

### DIFF
--- a/R/phase1_parse_csv.R
+++ b/R/phase1_parse_csv.R
@@ -1018,6 +1018,8 @@ read_dag <- function(where = ".", Application = NULL, dfl = NULL) {
       select(-"Container", -"Origin") %>%
       # 2. Dest becomes ResourceId for these MPI tasks
       rename(ResourceId = "Dest") %>%
+      mutate(ResourceId = as.character(.data$ResourceId)) %>%
+      filter(!(MPIType == 'x' & grepl("^CPU|^CUDA", ResourceId))) %>%
       mutate(ResourceId = as.factor(.data$ResourceId)) %>%
       separate_res() %>%
       tibble() %>%


### PR DESCRIPTION
- Adjusted ResourceId filtering to prevent splitting errors in separate_res function.
- Prevented errors caused by splitting ResourceId values like "CUDA0_0", which resulted in invalid conversions during integer parsing.

**Important**: I didn't run the unit tests.

Fxt to reproduce the issue: [prof_file_1.zip](https://github.com/user-attachments/files/17602989/prof_file_1.zip)

fixes: #22 
