### PR TITLE
Flake de compilação

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,251 @@
+{
+  "nodes": {
+    "cudaNixpkgs": {
+      "locked": {
+        "lastModified": 1738797219,
+        "narHash": "sha256-KRwX9Z1XavpgeSDVM/THdFd6uH8rNm/6R+7kIbGa+2s=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1da52dd49a127ad74486b135898da2cef8c62665",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1da52dd49a127ad74486b135898da2cef8c62665",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772963539,
+        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1772963539,
+        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1772963539,
+        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1772773019,
+        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pajeng": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1773239180,
+        "narHash": "sha256-bGzBAgJCAvfgEISTVqR2/H41UBjjwx5hHCfD773GM/g=",
+        "owner": "schnorr",
+        "repo": "pajeng",
+        "rev": "2926ab4208eb5d8b11f8fa33f35c2d40c86480f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "schnorr",
+        "repo": "pajeng",
+        "type": "github"
+      }
+    },
+    "poti": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1773239076,
+        "narHash": "sha256-zGheCiUJS2NWIjt8FOtLsELSRlasjx9/lU62Vb6VGAc=",
+        "owner": "schnorr",
+        "repo": "poti",
+        "rev": "9f5f366749f771f9f2129361bd56182a615a060e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "schnorr",
+        "repo": "poti",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pajeng": "pajeng",
+        "poti": "poti",
+        "starpu": "starpu"
+      }
+    },
+    "starpu": {
+      "inputs": {
+        "cudaNixpkgs": "cudaNixpkgs",
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "lastModified": 1773148565,
+        "narHash": "sha256-6nTK5Bqx0vBpMjzTvbtzPQqH1VCy8qML3xfRDcAK9KU=",
+        "owner": "Sacolle",
+        "repo": "nix-starpu",
+        "rev": "664a1eacd12f301738e97f08d68793fa28becec0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Sacolle",
+        "repo": "nix-starpu",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+	description = ''Flake for the derivation of the R package starvz 
+	and the tool starvz, compiled as the package starvz-tool'';
+
+	inputs = {
+		nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+		flake-utils.url = "github:numtide/flake-utils";
+		starpu.url = "github:Sacolle/nix-starpu";
+		poti.url = "github:schnorr/poti";
+		pajeng.url = "github:schnorr/pajeng";
+	};
+
+	outputs = { self, nixpkgs, flake-utils, starpu, poti, pajeng }: 
+	flake-utils.lib.eachDefaultSystem (system:
+	let
+		StarPU = (starpu.packages.${system}.default.override {
+			enableCUDA = false;
+			enableTrace = true;
+            extraOptions = [ "--enable-maxcpus=256" ];
+		});
+		pkgs = import nixpkgs { inherit system; };
+		starvz = pkgs.callPackage ./starvz.nix {};
+		starvzTools = pkgs.callPackage ./starvzTools.nix { 
+			poti = poti.packages.${system}.default;
+			pajeng = pajeng.packages.${system}.default;
+            inherit StarPU starvz; 
+        };
+	in
+	{
+		packages.${system} = {
+			default = starvzTools;
+            inherit starvz starvzTools;
+		};
+	});
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,6 @@
         };
 	in
 	{
-        # defaultPackage = self.packages.${system}.starvzTools;
 		packages = rec {
             default = starvzTools;
             inherit starvz starvzTools;

--- a/flake.nix
+++ b/flake.nix
@@ -21,14 +21,15 @@
 		pkgs = import nixpkgs { inherit system; };
 		starvz = pkgs.callPackage ./starvz.nix {};
 		starvzTools = pkgs.callPackage ./starvzTools.nix { 
-			poti = poti.packages.${system}.default;
-			pajeng = pajeng.packages.${system}.default;
+			poti = poti.packages.${system}.poti;
+			pajeng = pajeng.packages.${system}.pajeng;
             inherit StarPU starvz; 
         };
 	in
 	{
-		packages.${system} = {
-			default = starvzTools;
+        # defaultPackage = self.packages.${system}.starvzTools;
+		packages = rec {
+            default = starvzTools;
             inherit starvz starvzTools;
 		};
 	});

--- a/starvz.nix
+++ b/starvz.nix
@@ -1,0 +1,48 @@
+{ 
+    lib,
+    fetchFromGitHub,
+    rPackages,
+    # StarPU,
+    arrow-cpp,
+    pkg-config,
+    R
+}:
+rPackages.buildRPackage {
+    name = "starvz";
+
+    src = fetchFromGitHub {
+        owner = "schnorr";
+        repo = "starvz";
+        rev = "CRAN_0.7.1";
+        hash = "sha256-zTwr08/0hFdzk/vsxQ2N0MRmEFDm2twYsmVBgXPxpow=";
+    };
+    nativeBuildInputs = [ pkg-config R  rPackages.arrow];
+
+    buildInputs = [ arrow-cpp 
+    # StarPU 
+    ];
+
+    propagatedBuildInputs = with rPackages; [
+        rPackages.arrow
+        magrittr
+        dplyr
+        ggplot2
+        tibble
+        rlang
+        tidyr
+        patchwork
+        purrr
+        readr
+        stringr
+        yaml
+        lpSolve
+        gtools
+        data_tree
+        RColorBrewer
+        zoo
+        Rcpp
+        BH
+    ];
+
+    doCheck = true;
+}

--- a/starvz.nix
+++ b/starvz.nix
@@ -1,8 +1,6 @@
 { 
     lib,
-    fetchFromGitHub,
     rPackages,
-    # StarPU,
     arrow-cpp,
     pkg-config,
     R
@@ -10,17 +8,10 @@
 rPackages.buildRPackage {
     name = "starvz";
 
-    src = fetchFromGitHub {
-        owner = "schnorr";
-        repo = "starvz";
-        rev = "CRAN_0.7.1";
-        hash = "sha256-zTwr08/0hFdzk/vsxQ2N0MRmEFDm2twYsmVBgXPxpow=";
-    };
+    src = ./.;
     nativeBuildInputs = [ pkg-config R  rPackages.arrow];
 
-    buildInputs = [ arrow-cpp 
-    # StarPU 
-    ];
+    buildInputs = [ arrow-cpp ];
 
     propagatedBuildInputs = with rPackages; [
         rPackages.arrow

--- a/starvzTools.nix
+++ b/starvzTools.nix
@@ -28,38 +28,33 @@ in
     name = "starvz-tools";
     version = "0.7.1";
 
-    src = fetchFromGitHub {
-        owner = "schnorr";
-        repo = "starvz";
-        rev = "CRAN_${f.version}";
-        hash = "sha256-zTwr08/0hFdzk/vsxQ2N0MRmEFDm2twYsmVBgXPxpow=";
-    };
+    src = ./inst;
     nativeBuildInputs = [ 
          makeWrapper
          myR
     ];
     patchPhase = ''
-        patchShebangs inst/tools/*.R
-        patchShebangs inst/tools/*.sh
+        patchShebangs tools/*.R
+        patchShebangs tools/*.sh
     '';
 
     buildInputs = [ zlib ];
 
     buildPhase = ''
-        $CC -O2 inst/tools/starvz_csv.c -o starvz_fast_csv_split -lz -fopenmp
+        $CC -O2 tools/starvz_csv.c -o starvz_fast_csv_split -lz -fopenmp
     '';
 
     installPhase = ''
         # tools/ (STARVZ_HOME/tools/)
         mkdir -p $out/tools
-        cp inst/tools/*.sh inst/tools/*.R inst/tools/starvz inst/tools/starvz_csv.c $out/tools/
+        cp tools/*.sh tools/*.R tools/starvz tools/starvz_csv.c $out/tools/
         cp starvz_fast_csv_split $out/tools/
         chmod +x $out/tools/*.sh $out/tools/starvz
         patch
 
         # etc/ (STARVZ_HOME/etc/)
         mkdir -p $out/etc
-        cp -r inst/etc/* $out/etc/
+        cp -r etc/* $out/etc/
 
         # bin/starvz — placed here so that STARVZ_HOME=$(dirname $0)/..=$out
         mkdir -p $out/bin

--- a/starvzTools.nix
+++ b/starvzTools.nix
@@ -1,0 +1,75 @@
+{ 
+    stdenv,
+    lib,
+    fetchFromGitHub,
+    StarPU,
+    pkg-config,
+    makeWrapper,
+    rWrapper,
+    zlib,
+    recutils,
+
+    starvz,
+    poti,
+    pajeng
+}:
+stdenv.mkDerivation (f: 
+let
+    myR = (rWrapper.override { packages = [ starvz ]; });
+    starvzPath = lib.makeBinPath [ 
+        myR 
+        poti 
+        pajeng 
+        StarPU 
+        recutils 
+    ];
+in
+{
+    name = "starvz-tools";
+    version = "0.7.1";
+
+    src = fetchFromGitHub {
+        owner = "schnorr";
+        repo = "starvz";
+        rev = "CRAN_${f.version}";
+        hash = "sha256-zTwr08/0hFdzk/vsxQ2N0MRmEFDm2twYsmVBgXPxpow=";
+    };
+    nativeBuildInputs = [ 
+         makeWrapper
+         myR
+    ];
+    patchPhase = ''
+        patchShebangs inst/tools/*.R
+        patchShebangs inst/tools/*.sh
+    '';
+
+    buildInputs = [ zlib ];
+
+    buildPhase = ''
+        $CC -O2 inst/tools/starvz_csv.c -o starvz_fast_csv_split -lz -fopenmp
+    '';
+
+    installPhase = ''
+        # tools/ (STARVZ_HOME/tools/)
+        mkdir -p $out/tools
+        cp inst/tools/*.sh inst/tools/*.R inst/tools/starvz inst/tools/starvz_csv.c $out/tools/
+        cp starvz_fast_csv_split $out/tools/
+        chmod +x $out/tools/*.sh $out/tools/starvz
+        patch
+
+        # etc/ (STARVZ_HOME/etc/)
+        mkdir -p $out/etc
+        cp -r inst/etc/* $out/etc/
+
+        # bin/starvz — placed here so that STARVZ_HOME=$(dirname $0)/..=$out
+        mkdir -p $out/bin
+        cp $out/tools/starvz $out/bin/starvz
+        
+        # add a symlink to the script, so when runing nix run it finds it
+        ln -sf $out/bin/starvz $out/bin/starvz-tools
+
+        wrapProgram $out/bin/starvz \
+            --prefix PATH : ${starvzPath} \
+            --set R_LIBS_USER /nonexistent
+    '';
+})


### PR DESCRIPTION
Adiciona flake.nix assim como arquivos auxiliares para compilar o pacote R stavz e a ferramenta starvz. Essa depende dos pacotes pajeng e poti. Já foi adicionado nesses outros dois repos um flake, então a entrada está limpa.